### PR TITLE
pass code and reason to close event

### DIFF
--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -487,8 +487,8 @@ function (_EventEmitter) {
       return _this.emit("error", error);
     };
 
-    _this.socket.onclose = function () {
-      return _this.emit("close");
+    _this.socket.onclose = function (event) {
+      _this.emit("close", event.code, event.reason);
     };
 
     return _this;

--- a/dist/lib/client/websocket.browser.js
+++ b/dist/lib/client/websocket.browser.js
@@ -54,8 +54,8 @@ function (_EventEmitter) {
       return _this.emit("error", error);
     };
 
-    _this.socket.onclose = function () {
-      return _this.emit("close");
+    _this.socket.onclose = function (event) {
+      _this.emit("close", event.code, event.reason);
     };
 
     return _this;

--- a/src/lib/client/websocket.browser.js
+++ b/src/lib/client/websocket.browser.js
@@ -25,7 +25,10 @@ export default class WebSocket extends EventEmitter
         this.socket.onopen = () => this.emit("open")
         this.socket.onmessage = (event) => this.emit("message", event.data)
         this.socket.onerror = (error) => this.emit("error", error)
-        this.socket.onclose = () => this.emit("close")
+        this.socket.onclose = (event) =>
+        {
+            this.emit("close", event.code, event.reason)
+        }
     }
 
     /**


### PR DESCRIPTION
to prevent automatic re-open of connection after closing it

the "close" event handler returns if the code is 1000, but the code is not passed to the event, so the websocket will always be re-opened, even if explicitly closed