### PR TITLE
fix eventemitter3 typescript imports

### DIFF
--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -3,7 +3,7 @@
  * according to the environment providing JSON RPC 2.0 support on top.
  * @module Client
  */
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "eventemitter3";
 import { NodeWebSocketType, ICommonWebSocketFactory } from "./client/client.types";
 interface IQueueElement {
     promise: [Parameters<ConstructorParameters<typeof Promise>[0]>[0], Parameters<ConstructorParameters<typeof Promise>[0]>[1]];

--- a/dist/lib/client/websocket.browser.d.ts
+++ b/dist/lib/client/websocket.browser.d.ts
@@ -2,7 +2,7 @@
  * WebSocket implements a browser-side WebSocket specification.
  * @module Client
  */
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "eventemitter3";
 import { BrowserWebSocketType, NodeWebSocketType, IWSClientAdditionalOptions } from "./client.types";
 declare class WebSocketBrowserImpl extends EventEmitter {
     socket: BrowserWebSocketType;

--- a/dist/lib/server.d.ts
+++ b/dist/lib/server.d.ts
@@ -2,7 +2,7 @@
  * "Server" wraps the "ws" library providing JSON RPC 2.0 support on top.
  * @module Server
  */
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "eventemitter3";
 import NodeWebSocket, { Server as WebSocketServer } from "ws";
 interface INamespaceEvent {
     [x: string]: Array<string>;


### PR DESCRIPTION
some .d.ts files have wrong imports which broke typescript compiler

 ERROR src/node_modules/rpc-websockets/lib/client.d.ts(6,8): error TS1192: Module '"src/node_modules/eventemitter3/index"' has no default export.
 src/web-socket.service.ts(33,24): error TS2339: Property 'on' does not exist on type 'Client'.


