### PR TITLE
Change arguments[1] to arguments[2]

### DIFF
--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -24,7 +24,7 @@ export default class CommonClient extends EventEmitter {
         this.queue = {};
         this.rpc_id = 0;
         this.address = address;
-        this.options = arguments[1];
+        this.options = arguments[2];
         this.autoconnect = autoconnect;
         this.ready = false;
         this.reconnect = reconnect;

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -124,7 +124,7 @@ function (_EventEmitter) {
     _this.queue = {};
     _this.rpc_id = 0;
     _this.address = address;
-    _this.options = arguments[1];
+    _this.options = arguments[2];
     _this.autoconnect = autoconnect;
     _this.ready = false;
     _this.reconnect = reconnect;

--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -3,7 +3,7 @@
  * according to the environment providing JSON RPC 2.0 support on top.
  * @module Client
  */
-import { EventEmitter } from "eventemitter3";
+import EventEmitter from "eventemitter3";
 import { NodeWebSocketType, ICommonWebSocketFactory } from "./client/client.types";
 interface IQueueElement {
     promise: [Parameters<ConstructorParameters<typeof Promise>[0]>[0], Parameters<ConstructorParameters<typeof Promise>[0]>[1]];

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -68,7 +68,7 @@ function (_EventEmitter) {
     _this.queue = {};
     _this.rpc_id = 0;
     _this.address = address;
-    _this.options = arguments[1];
+    _this.options = arguments[2];
     _this.autoconnect = autoconnect;
     _this.ready = false;
     _this.reconnect = reconnect;

--- a/dist/lib/client/websocket.browser.d.ts
+++ b/dist/lib/client/websocket.browser.d.ts
@@ -2,7 +2,7 @@
  * WebSocket implements a browser-side WebSocket specification.
  * @module Client
  */
-import { EventEmitter } from "eventemitter3";
+import EventEmitter from "eventemitter3";
 import { BrowserWebSocketType, NodeWebSocketType, IWSClientAdditionalOptions } from "./client.types";
 declare class WebSocketBrowserImpl extends EventEmitter {
     socket: BrowserWebSocketType;

--- a/dist/lib/server.d.ts
+++ b/dist/lib/server.d.ts
@@ -2,7 +2,7 @@
  * "Server" wraps the "ws" library providing JSON RPC 2.0 support on top.
  * @module Server
  */
-import { EventEmitter } from "eventemitter3";
+import EventEmitter from "eventemitter3";
 import NodeWebSocket, { Server as WebSocketServer } from "ws";
 interface INamespaceEvent {
     [x: string]: Array<string>;

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -80,7 +80,7 @@ export default class CommonClient extends EventEmitter
         this.rpc_id = 0
 
         this.address = address
-        this.options = arguments[1]
+        this.options = arguments[2]
         this.autoconnect = autoconnect
         this.ready = false
         this.reconnect = reconnect


### PR DESCRIPTION
This fixes https://github.com/elpheria/rpc-websockets/issues/55 for me. I'm not sure if there are other potential problems this could introduce though. It may be better to just use a named parameter here instead of accessing it by its index anyway.