### PR TITLE
pass options into ws instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,6 +65,7 @@ Parameters:
   * `reconnect` {Boolean}: Whether client should reconnect automatically once the connection is down. Defaults to `true`.
   * `reconnect_interval` {Number}: Time between adjacent reconnects. Defaults to `1000`.
   * `max_reconnects` {Number}: Maximum number of times the client should try to reconnect. Defaults to `5`. `0` means unlimited.
+  * Any other option allowed in <a href="https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options" target="_blank">Node WebSocket</a>
 * `generate_request_id` {Function} Custom function to generate request id instead of simple increment by default. Passes `method` and `params` to parameters.
 
 ### ws.connect()

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ export class Client extends CommonClient
             autoconnect = true,
             reconnect = true,
             reconnect_interval = 1000,
-            max_reconnects = 5
+            max_reconnects = 5,
+            ...rest_options
         }: IWSClientAdditionalOptions & NodeWebSocketTypeOptions = {},
         generate_request_id?: (method: string, params: object | Array<any>) => number
     )
@@ -24,7 +25,8 @@ export class Client extends CommonClient
                 autoconnect,
                 reconnect,
                 reconnect_interval,
-                max_reconnects
+                max_reconnects,
+                ...rest_options
             },
             generate_request_id
         )


### PR DESCRIPTION
Not of all options are passed into ws instance now.
For example, without my suggestion, ws-server does not receive custom headers:
const Websocket = require('rpc-websockets').Client;
const options = {
  autoconnect: true,
  reconnect: false,
  headers: { 'x-header1': 'x-header1', 'x-header2': 'x-header2' } 
};
const ws = new Websocket('ws://localhost:8080', options);