### PR TITLE
Unset socket when closed to allow reconnects

### DIFF
--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -234,6 +234,7 @@ export default class CommonClient extends EventEmitter {
             if (this.ready)
                 this.emit("close", code, reason);
             this.ready = false;
+            this.socket = undefined;
             if (code === 1000)
                 return;
             this.current_reconnects++;

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -501,6 +501,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
             reason = _ref3.reason;
         if (_this4.ready) _this4.emit("close", code, reason);
         _this4.ready = false;
+        _this4.socket = undefined;
         if (code === 1000) return;
         _this4.current_reconnects++;
         if (_this4.reconnect && (_this4.max_reconnects > _this4.current_reconnects || _this4.max_reconnects === 0)) setTimeout(function () {

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -441,6 +441,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
             reason = _ref3.reason;
         if (_this4.ready) _this4.emit("close", code, reason);
         _this4.ready = false;
+        _this4.socket = undefined;
         if (code === 1000) return;
         _this4.current_reconnects++;
         if (_this4.reconnect && (_this4.max_reconnects > _this4.current_reconnects || _this4.max_reconnects === 0)) setTimeout(function () {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -360,6 +360,7 @@ export default class CommonClient extends EventEmitter
                 this.emit("close", code, reason)
 
             this.ready = false
+            this.socket = undefined
 
             if (code === 1000)
                 return


### PR DESCRIPTION
Fixes: https://github.com/elpheria/rpc-websockets/issues/87

#### Problem
After socket is closed (and auto reconnect disabled) subsequent calls to `connect` will not open a new socket.

#### Changes
- Unset `this.socket` when closed