### PR TITLE
Delay close event until socket is reset

### DIFF
--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -231,8 +231,8 @@ export default class CommonClient extends EventEmitter {
         });
         this.socket.addEventListener("error", (error) => this.emit("error", error));
         this.socket.addEventListener("close", ({ code, reason }) => {
-            if (this.ready)
-                this.emit("close", code, reason);
+            if (this.ready) // Delay close event until internal state is updated
+                setTimeout(() => this.emit("close", code, reason), 0);
             this.ready = false;
             this.socket = undefined;
             if (code === 1000)

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -499,7 +499,10 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
       this.socket.addEventListener("close", function (_ref3) {
         var code = _ref3.code,
             reason = _ref3.reason;
-        if (_this4.ready) _this4.emit("close", code, reason);
+        if (_this4.ready) // Delay close event until internal state is updated
+          setTimeout(function () {
+            return _this4.emit("close", code, reason);
+          }, 0);
         _this4.ready = false;
         _this4.socket = undefined;
         if (code === 1000) return;

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -439,7 +439,10 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
       this.socket.addEventListener("close", function (_ref3) {
         var code = _ref3.code,
             reason = _ref3.reason;
-        if (_this4.ready) _this4.emit("close", code, reason);
+        if (_this4.ready) // Delay close event until internal state is updated
+          setTimeout(function () {
+            return _this4.emit("close", code, reason);
+          }, 0);
         _this4.ready = false;
         _this4.socket = undefined;
         if (code === 1000) return;

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -356,8 +356,8 @@ export default class CommonClient extends EventEmitter
 
         this.socket.addEventListener("close", ({code, reason}) =>
         {
-            if (this.ready)
-                this.emit("close", code, reason)
+            if (this.ready) // Delay close event until internal state is updated
+                setTimeout(() => this.emit("close", code, reason), 0)
 
             this.ready = false
             this.socket = undefined


### PR DESCRIPTION
#### Problem
The close event is emitted before setting `this.socket = undefined` and events are handled synchronously. This means that any client which decides to call `connect()` from a "close" event listener, will no-op because `function connect()` first checks if `this.socket` is defined.

#### Changes
- Delay "close" event until next event loop to ensure that local socket state is updated beforehand