### PR TITLE
Client: Check if response violates spec; throw Error; add hints

### DIFF
--- a/API.md
+++ b/API.md
@@ -81,7 +81,7 @@ Connects to a previously defined server if not connected already. Should only be
 
 ### ws.call(method[, params[, timeout[, ws_options]]]) -> Promise
 
-Calls a registered RPC method on server. Resolves once the response is ready. Throws if an RPC error was received.
+Calls a registered RPC method on server. Resolves once the response is ready. Throws if an RPC error was received. Throws if `method` resolves to `undefined` (JSON knows no `undefined` type, so the response will neither have `result` nor `error` properties which violates JSON-RPC 2.0).
 
 Parameters:
 * `method` {String}: An RPC method name to run on server-side.
@@ -189,7 +189,7 @@ Registers an RPC method and returns the RPCMethod object to manage method permis
 
 Parameters:
 * `method` {String}: RPC method name.
-* `handler` {Function}: RPC function that will be fired with a signature of `([params[, socket_id]])` once the method is called.
+* `handler` {Function}: RPC function that will be fired with a signature of `([params[, socket_id]])` once the method is called. Should not return `undefined` (see [ws.call](#wscallmethod-params-timeout-ws_options---promise)).
 * `namespace` {String}: Namespace identifier. Defaults to ```/```.
 
 ### server.setAuth(handler[, namespace])

--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -222,8 +222,9 @@ export default class CommonClient extends EventEmitter {
                 return;
             }
             // reject early since server's response is invalid
-            if (message.error === undefined && message.result === undefined)
-                this.queue[message.id].promise[1]("server response malformed");
+            if ("error" in message === "result" in message)
+                this.queue[message.id].promise[1](new Error("Server response malformed. Response must include either \"result\"" +
+                    " or \"error\", but not both."));
             if (this.queue[message.id].timeout)
                 clearTimeout(this.queue[message.id].timeout);
             if (message.error)

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -490,7 +490,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
         } // reject early since server's response is invalid
 
 
-        if (message.error === undefined && message.result === undefined) _this4.queue[message.id].promise[1]("server response malformed");
+        if ("error" in message === "result" in message) _this4.queue[message.id].promise[1](new Error("Server response malformed. Response must include either \"result\"" + " or \"error\", but not both."));
         if (_this4.queue[message.id].timeout) clearTimeout(_this4.queue[message.id].timeout);
         if (message.error) _this4.queue[message.id].promise[1](message.error);else _this4.queue[message.id].promise[0](message.result);
         _this4.queue[message.id] = null;

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -430,7 +430,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
         } // reject early since server's response is invalid
 
 
-        if (message.error === undefined && message.result === undefined) _this4.queue[message.id].promise[1]("server response malformed");
+        if ("error" in message === "result" in message) _this4.queue[message.id].promise[1](new Error("Server response malformed. Response must include either \"result\"" + " or \"error\", but not both."));
         if (_this4.queue[message.id].timeout) clearTimeout(_this4.queue[message.id].timeout);
         if (message.error) _this4.queue[message.id].promise[1](message.error);else _this4.queue[message.id].promise[0](message.result);
         _this4.queue[message.id] = null;

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -342,8 +342,11 @@ export default class CommonClient extends EventEmitter
             }
 
             // reject early since server's response is invalid
-            if (message.error === undefined && message.result === undefined)
-                this.queue[message.id].promise[1]("server response malformed")
+            if ("error" in message === "result" in message)
+                this.queue[message.id].promise[1](new Error(
+                    "Server response malformed. Response must include either \"result\"" +
+                    " or \"error\", but not both."
+                ))
 
             if (this.queue[message.id].timeout)
                 clearTimeout(this.queue[message.id].timeout)


### PR DESCRIPTION
30a2192 does not fully resolve #91, since it does not check if both `result` and `error` are included in the response object at the same time. I also think we should prefer throwing an Error instead of a string.

Also, the changes introduced in 30a2192 make it impossible to return `undefined` in RPCs. This is a result of the spec, and I believe there is nothing we can do about it. I think we should add hints in the API; they might be useful for anyone who would like to start using rpc-websockets.

(This is my first pull request. Please let me know if I did not follow common practice. Thanks a lot in advance!)