### PR TITLE
fix(server): check message for null

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -537,7 +537,7 @@ export default class Server extends EventEmitter
      */
     private async _runMethod(message: any, socket_id: string, ns = "/")
     {
-        if (typeof message !== "object")
+        if (typeof message !== "object" || message === null)
             return {
                 jsonrpc: "2.0",
                 error: utils.createError(-32600),

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -616,6 +616,30 @@ describe("Server", function()
                 })
             })
 
+            it("should respond with -32600 when request data is null", function(done)
+            {
+                connect(port, host).then(function(ws)
+                {
+                    const data = "null";
+                    ws.send(data)
+
+                    ws.on("message", function(message)
+                    {
+                        message = JSON.parse(message)
+                        message.error.code.should.equal(-32600)
+                        message.error.message.should.equal("Invalid Request")
+
+                        ws.close()
+                        done()
+                    })
+
+                    ws.once("error", function(error)
+                    {
+                        done(error)
+                    })
+                })
+            })
+
             it("should respond with -32600 when called with invalid method name in JSON-RPC 2.0 Request object", function(done)
             {
                 connect(port, host).then(function(ws)


### PR DESCRIPTION
when the request is null:
```bash
wscat -c localhost:8080
> null
Disconnected (code: 1006, reason: "")
```

server logs:
```
/home/XXXX/scratch/rpc-websockets/node_modules/rpc-websockets/dist/lib/server.js:687
                if (!(message.jsonrpc !== "2.0")) {
                              ^

TypeError: Cannot read property 'jsonrpc' of null
    at Server._callee2$ (/home/XXXX/scratch/rpc-websockets/node_modules/rpc-websockets/dist/lib/server.js:687:31)
    at tryCatch (/home/XXXX/scratch/rpc-websockets/node_modules/regenerator-runtime/runtime.js:63:40)
    at Generator.invoke [as _invoke] (/home/XXXX/scratch/rpc-websockets/node_modules/regenerator-runtime/runtime.js:293:22)
    at Generator.next (/home/XXXX/scratch/rpc-websockets/node_modules/regenerator-runtime/runtime.js:118:21)
    at asyncGeneratorStep (/home/XXXX/scratch/rpc-websockets/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/home/XXXX/scratch/rpc-websockets/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
    at /home/XXXX/scratch/rpc-websockets/node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
    at new Promise (<anonymous>)
    at Server.<anonymous> (/home/XXXX/scratch/rpc-websockets/node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12)
    at Server._runMethod (/home/XXXX/scratch/rpc-websockets/node_modules/rpc-websockets/dist/lib/server.js:1034:28)

```