### PR TITLE
Fix license metadata in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "server"
   ],
   "author": "Elpheria",
-  "license": "MIT",
+  "license": "LGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/elpheria/rpc-websockets/issues"
   },


### PR DESCRIPTION
Currently, incorrect license metadata is causing the licence to be displayed wrong on the NPM sidebar, since NPM uses the metadata in the `package.json` to determine what to put in the sidebar:
![image](https://user-images.githubusercontent.com/10530973/113420151-cc7c2e80-9396-11eb-89b6-ba065f317a27.png)