### PR TITLE
Pass socket_id to setAuth

### DIFF
--- a/build-ts/lib/server.d.ts
+++ b/build-ts/lib/server.d.ts
@@ -59,7 +59,7 @@ export default class Server extends EventEmitter {
      * @throws {TypeError}
      * @return {Undefined}
      */
-    setAuth(fn: (params: IRPCMethodParams) => boolean, ns?: string): void;
+    setAuth(fn: (params: IRPCMethodParams, socket_id: string) => boolean, ns?: string): void;
     /**
      * Marks an RPC method as protected.
      * @method

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -168,7 +168,7 @@ export default class Server extends EventEmitter
      * @throws {TypeError}
      * @return {Undefined}
      */
-    setAuth(fn: (params: IRPCMethodParams) => boolean, ns = "/")
+    setAuth(fn: (params: IRPCMethodParams, socket_id: string) => boolean, ns = "/")
     {
         this.register("rpc.login", fn, ns)
     }

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -333,10 +333,15 @@ describe("Server", function()
                 host = server.wss.options.host
                 port = server.wss.options.port
 
-                inst.setAuth(function(data)
+                auth_id = null
+
+                inst.setAuth(function(data, socket_id)
                 {
                     if (data.username === "foo" && data.password === "bar")
+                    {
+                        auth_id = socket_id
                         return true
+                    }
                     else
                         return false
                 })
@@ -346,8 +351,9 @@ describe("Server", function()
                     return Math.sqrt(param)
                 })
 
-                inst.register("sqrt_protected", function(param)
+                inst.register("sqrt_protected", function(param, socket_id)
                 {
+                    if(auth_id !== socket_id) throw "Socket ID does not match!";
                     return Math.sqrt(param)
                 }).protected()
 


### PR DESCRIPTION
The socket_id parameter is already passed through the register method, however this is not typed.  Passing the socket_id into the auth function allows storing information about the user (ex. their username or authorization level).

Additionally added a test to ensure that the ID stays consistent.  Wasn't able to run tests locally (npm run test gave unrelated errors) but this should be a fairly trivial change.