### PR TITLE
Use delete to avoid memory leak

### DIFF
--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -86,7 +86,7 @@ export default class CommonClient extends EventEmitter {
                 this.queue[rpc_id] = { promise: [resolve, reject] };
                 if (timeout) {
                     this.queue[rpc_id].timeout = setTimeout(() => {
-                        this.queue[rpc_id] = null;
+                        delete this.queue[rpc_id];
                         reject(new Error("reply timeout"));
                     }, timeout);
                 }
@@ -235,7 +235,7 @@ export default class CommonClient extends EventEmitter {
                 this.queue[message.id].promise[1](message.error);
             else
                 this.queue[message.id].promise[0](message.result);
-            this.queue[message.id] = null;
+            delete this.queue[message.id];
         });
         this.socket.addEventListener("error", (error) => this.emit("error", error));
         this.socket.addEventListener("close", ({ code, reason }) => {

--- a/dist/index.browser-bundle.js
+++ b/dist/index.browser-bundle.js
@@ -228,7 +228,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
 
           if (timeout) {
             _this2.queue[rpc_id].timeout = setTimeout(function () {
-              _this2.queue[rpc_id] = null;
+              delete _this2.queue[rpc_id];
               reject(new Error("reply timeout"));
             }, timeout);
           }
@@ -514,7 +514,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
         if ("error" in message === "result" in message) _this4.queue[message.id].promise[1](new Error("Server response malformed. Response must include either \"result\"" + " or \"error\", but not both."));
         if (_this4.queue[message.id].timeout) clearTimeout(_this4.queue[message.id].timeout);
         if (message.error) _this4.queue[message.id].promise[1](message.error);else _this4.queue[message.id].promise[0](message.result);
-        _this4.queue[message.id] = null;
+        delete _this4.queue[message.id];
       });
       this.socket.addEventListener("error", function (error) {
         return _this4.emit("error", error);

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -168,7 +168,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
 
           if (timeout) {
             _this2.queue[rpc_id].timeout = setTimeout(function () {
-              _this2.queue[rpc_id] = null;
+              delete _this2.queue[rpc_id];
               reject(new Error("reply timeout"));
             }, timeout);
           }
@@ -454,7 +454,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
         if ("error" in message === "result" in message) _this4.queue[message.id].promise[1](new Error("Server response malformed. Response must include either \"result\"" + " or \"error\", but not both."));
         if (_this4.queue[message.id].timeout) clearTimeout(_this4.queue[message.id].timeout);
         if (message.error) _this4.queue[message.id].promise[1](message.error);else _this4.queue[message.id].promise[0](message.result);
-        _this4.queue[message.id] = null;
+        delete _this4.queue[message.id];
       });
       this.socket.addEventListener("error", function (error) {
         return _this4.emit("error", error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "7.4.13",
+      "name": "rpc-websockets",
+      "version": "7.4.15",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -3422,6 +3423,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
       "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"
@@ -8950,6 +8952,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
       "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -166,7 +166,7 @@ export default class CommonClient extends EventEmitter
                 {
                     this.queue[rpc_id].timeout = setTimeout(() =>
                     {
-                        this.queue[rpc_id] = null
+                        delete this.queue[rpc_id]
                         reject(new Error("reply timeout"))
                     }, timeout)
                 }
@@ -363,7 +363,7 @@ export default class CommonClient extends EventEmitter
             else
                 this.queue[message.id].promise[0](message.result)
 
-            this.queue[message.id] = null
+            delete this.queue[message.id]
         })
 
         this.socket.addEventListener("error", (error) => this.emit("error", error))


### PR DESCRIPTION
Hey there! I'm using your library via a somewhat involved chain of dependencies, and I've been running into a memory leak. I debugged it using the node's heap inspector and I found that the `queue` object here continuously grows in size because its keys never get deleted. The object looks like `{1: null, 2: null, 3: null, ...}`.

The fix is pretty easy -- just use `delete` to remove the key from the object in addition to the value.

The main change is the delete thing ^. Some other files seem to have changed when I made the change above and ran `test` and I'm not sure why. I'm kind of a noob to the js ecosystem, so please tell me if I should revert some of those changes.