### PR TITLE
Remove circular-json dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
-        "circular-json": "^0.5.9",
         "eventemitter3": "^4.0.7",
         "flatted": "^3.2.5",
         "uuid": "^8.3.2",
@@ -4150,12 +4149,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/circular-json": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
-      "deprecated": "CircularJSON is in maintenance only, flatted is its successor."
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -11661,11 +11654,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "circular-json": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
     },
     "cliui": {
       "version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
-    "circular-json": "^0.5.9",
     "eventemitter3": "^4.0.7",
     "flatted": "^3.2.5",
     "uuid": "^8.3.2",


### PR DESCRIPTION
The project switched to `flatted` with commit c15daf6 but the unused dependency `circular-json` was left. With this commit, it is removed.

Fixes #85.