### PR TITLE
Fix inputs and outputs to be valid JSON again

### DIFF
--- a/build-ts/lib/client.js
+++ b/build-ts/lib/client.js
@@ -17,7 +17,6 @@ var __rest = (this && this.__rest) || function (s, e) {
 };
 // @ts-ignore
 import { EventEmitter } from "eventemitter3";
-import { stringify, parse } from "flatted";
 export default class CommonClient extends EventEmitter {
     /**
      * Instantiate a Client class.
@@ -80,7 +79,7 @@ export default class CommonClient extends EventEmitter {
                 params: params || null,
                 id: rpc_id
             };
-            this.socket.send(stringify(message), ws_opts, (error) => {
+            this.socket.send(JSON.stringify(message), ws_opts, (error) => {
                 if (error)
                     return reject(error);
                 this.queue[rpc_id] = { promise: [resolve, reject] };
@@ -129,7 +128,7 @@ export default class CommonClient extends EventEmitter {
                 method: method,
                 params: params || null
             };
-            this.socket.send(stringify(message), (error) => {
+            this.socket.send(JSON.stringify(message), (error) => {
                 if (error)
                     return reject(error);
                 resolve();
@@ -195,7 +194,7 @@ export default class CommonClient extends EventEmitter {
             if (message instanceof ArrayBuffer)
                 message = Buffer.from(message).toString();
             try {
-                message = parse(message);
+                message = JSON.parse(message);
             }
             catch (error) {
                 return;

--- a/build-ts/lib/server.js
+++ b/build-ts/lib/server.js
@@ -8,7 +8,6 @@ import { EventEmitter } from "eventemitter3";
 import { Server as WebSocketServer } from "ws";
 import { v1 as uuidv1 } from "uuid";
 import url from "url";
-import { stringify } from "flatted";
 import * as utils from "./utils";
 export default class Server extends EventEmitter {
     /**
@@ -181,7 +180,7 @@ export default class Server extends EventEmitter {
                 const socket = this.namespaces[ns].clients.get(socket_id);
                 if (!socket)
                     continue;
-                socket.send(stringify({
+                socket.send(JSON.stringify({
                     notification: name,
                     params: params || null
                 }));
@@ -237,7 +236,7 @@ export default class Server extends EventEmitter {
             emit(event, ...params) {
                 const socket_ids = [...self.namespaces[name].clients.keys()];
                 for (let i = 0, id; id = socket_ids[i]; ++i) {
-                    self.namespaces[name].clients.get(id).send(stringify({
+                    self.namespaces[name].clients.get(id).send(JSON.stringify({
                         notification: event,
                         params: params || []
                     }));
@@ -339,7 +338,7 @@ export default class Server extends EventEmitter {
                 parsedData = JSON.parse(data);
             }
             catch (error) {
-                return socket.send(stringify({
+                return socket.send(JSON.stringify({
                     jsonrpc: "2.0",
                     error: utils.createError(-32700, error.toString()),
                     id: null
@@ -347,7 +346,7 @@ export default class Server extends EventEmitter {
             }
             if (Array.isArray(parsedData)) {
                 if (!parsedData.length)
-                    return socket.send(stringify({
+                    return socket.send(JSON.stringify({
                         jsonrpc: "2.0",
                         error: utils.createError(-32600, "Invalid array"),
                         id: null
@@ -361,12 +360,12 @@ export default class Server extends EventEmitter {
                 }
                 if (!responses.length)
                     return;
-                return socket.send(stringify(responses), msg_options);
+                return socket.send(JSON.stringify(responses), msg_options);
             }
             const response = await this._runMethod(parsedData, socket._id, ns);
             if (!response)
                 return;
-            return socket.send(stringify(response), msg_options);
+            return socket.send(JSON.stringify(response), msg_options);
         });
     }
     /**

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -30,8 +30,6 @@ var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/ge
 
 var _eventemitter = require("eventemitter3");
 
-var _flatted = require("flatted");
-
 function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
 
 function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
@@ -160,7 +158,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
           id: rpc_id
         };
 
-        _this2.socket.send((0, _flatted.stringify)(message), ws_opts, function (error) {
+        _this2.socket.send(JSON.stringify(message), ws_opts, function (error) {
           if (error) return reject(error);
           _this2.queue[rpc_id] = {
             promise: [resolve, reject]
@@ -276,7 +274,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
           params: params || null
         };
 
-        _this3.socket.send((0, _flatted.stringify)(message), function (error) {
+        _this3.socket.send(JSON.stringify(message), function (error) {
           if (error) return reject(error);
           resolve();
         });
@@ -418,7 +416,7 @@ var CommonClient = /*#__PURE__*/function (_EventEmitter) {
         if (message instanceof ArrayBuffer) message = Buffer.from(message).toString();
 
         try {
-          message = (0, _flatted.parse)(message);
+          message = JSON.parse(message);
         } catch (error) {
           return;
         } // check if any listeners are attached and forward event

--- a/dist/lib/server.js
+++ b/dist/lib/server.js
@@ -41,8 +41,6 @@ var _uuid = require("uuid");
 
 var _url = _interopRequireDefault(require("url"));
 
-var _flatted = require("flatted");
-
 var utils = _interopRequireWildcard(require("./utils"));
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -312,7 +310,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
             var socket = _this3.namespaces[ns].clients.get(socket_id);
 
             if (!socket) continue;
-            socket.send((0, _flatted.stringify)({
+            socket.send(JSON.stringify({
               notification: name,
               params: params || null
             }));
@@ -381,7 +379,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
           }
 
           for (var i = 0, id; id = socket_ids[i]; ++i) {
-            self.namespaces[name].clients.get(id).send((0, _flatted.stringify)({
+            self.namespaces[name].clients.get(id).send(JSON.stringify({
               notification: event,
               params: params || []
             }));
@@ -524,7 +522,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
                 case 8:
                   _context.prev = 8;
                   _context.t0 = _context["catch"](4);
-                  return _context.abrupt("return", socket.send((0, _flatted.stringify)({
+                  return _context.abrupt("return", socket.send(JSON.stringify({
                     jsonrpc: "2.0",
                     error: utils.createError(-32700, _context.t0.toString()),
                     id: null
@@ -541,7 +539,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
                     break;
                   }
 
-                  return _context.abrupt("return", socket.send((0, _flatted.stringify)({
+                  return _context.abrupt("return", socket.send(JSON.stringify({
                     jsonrpc: "2.0",
                     error: utils.createError(-32600, "Invalid array"),
                     id: null
@@ -607,7 +605,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
                   return _context.abrupt("return");
 
                 case 38:
-                  return _context.abrupt("return", socket.send((0, _flatted.stringify)(responses), msg_options));
+                  return _context.abrupt("return", socket.send(JSON.stringify(responses), msg_options));
 
                 case 39:
                   _context.next = 41;
@@ -624,7 +622,7 @@ var Server = /*#__PURE__*/function (_EventEmitter) {
                   return _context.abrupt("return");
 
                 case 44:
-                  return _context.abrupt("return", socket.send((0, _flatted.stringify)(response), msg_options));
+                  return _context.abrupt("return", socket.send(JSON.stringify(response), msg_options));
 
                 case 45:
                 case "end":

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
-        "flatted": "^3.2.5",
         "uuid": "^8.3.2",
         "ws": "^8.5.0"
       },
@@ -5343,7 +5342,8 @@
     "node_modules/flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -12604,7 +12604,8 @@
     "flatted": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "eventemitter3": "^4.0.7",
-    "flatted": "^3.2.5",
     "uuid": "^8.3.2",
     "ws": "^8.5.0"
   },

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,7 +9,6 @@
 import NodeWebSocket from "ws"
 // @ts-ignore
 import { EventEmitter } from "eventemitter3"
-import { stringify, parse } from "flatted"
 import {
     ICommonWebSocket,
     IWSClientAdditionalOptions,
@@ -155,7 +154,7 @@ export default class CommonClient extends EventEmitter
                 id: rpc_id
             }
 
-            this.socket.send(stringify(message), ws_opts, (error) =>
+            this.socket.send(JSON.stringify(message), ws_opts, (error) =>
             {
                 if (error)
                     return reject(error)
@@ -220,7 +219,7 @@ export default class CommonClient extends EventEmitter
                 params: params || null
             }
 
-            this.socket.send(stringify(message), (error) =>
+            this.socket.send(JSON.stringify(message), (error) =>
             {
                 if (error)
                     return reject(error)
@@ -309,7 +308,7 @@ export default class CommonClient extends EventEmitter
             if (message instanceof ArrayBuffer)
                 message = Buffer.from(message).toString()
 
-            try { message = parse(message) }
+            try { message = JSON.parse(message) }
 
             catch (error) { return }
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -10,7 +10,6 @@ import { EventEmitter } from "eventemitter3"
 import NodeWebSocket, { Server as WebSocketServer } from "ws"
 import { v1 as uuidv1 } from "uuid"
 import url from "url"
-import { stringify } from "flatted"
 
 import * as utils from "./utils"
 
@@ -282,7 +281,7 @@ export default class Server extends EventEmitter
                 if (!socket)
                     continue
 
-                socket.send(stringify({
+                socket.send(JSON.stringify({
                     notification: name,
                     params: params || null
                 }))
@@ -356,7 +355,7 @@ export default class Server extends EventEmitter
 
                 for (let i = 0, id; id = socket_ids[i]; ++i)
                 {
-                    self.namespaces[name].clients.get(id).send(stringify({
+                    self.namespaces[name].clients.get(id).send(JSON.stringify({
                         notification: event,
                         params: params || []
                     }))
@@ -484,7 +483,7 @@ export default class Server extends EventEmitter
 
             catch (error)
             {
-                return socket.send(stringify({
+                return socket.send(JSON.stringify({
                     jsonrpc: "2.0",
                     error: utils.createError(-32700, error.toString()),
                     id: null
@@ -494,7 +493,7 @@ export default class Server extends EventEmitter
             if (Array.isArray(parsedData))
             {
                 if (!parsedData.length)
-                    return socket.send(stringify({
+                    return socket.send(JSON.stringify({
                         jsonrpc: "2.0",
                         error: utils.createError(-32600, "Invalid array"),
                         id: null
@@ -515,7 +514,7 @@ export default class Server extends EventEmitter
                 if (!responses.length)
                     return
 
-                return socket.send(stringify(responses), msg_options)
+                return socket.send(JSON.stringify(responses), msg_options)
             }
 
             const response = await this._runMethod(parsedData, socket._id, ns)
@@ -523,7 +522,7 @@ export default class Server extends EventEmitter
             if (!response)
                 return
 
-            return socket.send(stringify(response), msg_options)
+            return socket.send(JSON.stringify(response), msg_options)
         })
     }
 

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -60,18 +60,6 @@ describe("Client", function()
                     })
                 })
 
-                server.register("circular", function()
-                {
-                    const Obj = function()
-                    {
-                        this.one = "one"
-                        this.two = "two"
-                        this.ref = this
-                    }
-
-                    return new Obj()
-                })
-
                 server.setAuth(function(data)
                 {
                     if (data.username === "foo" && data.password === "bar")
@@ -82,7 +70,6 @@ describe("Client", function()
 
                 server.event("newsUpdate")
                 server.event("newMessage")
-                server.event("circularUpdate")
                 server.event("newMessage", "/chat")
                 server.event("chatMessage", "/chat")
 
@@ -161,29 +148,6 @@ describe("Client", function()
                 client.call("sum", [5, 3]).then(function(response)
                 {
                     response.should.equal(8)
-
-                    done()
-                    client.close()
-                }, function(error)
-                {
-                    done(error)
-                })
-            })
-        })
-
-        it("should call an RPC method and receive a valid response when RPC method returns a circular object", function(done)
-        {
-            const client = new WebSocket("ws://" + host + ":" + port)
-
-            client.on("open", function()
-            {
-                client.call("circular").then(function(response)
-                {
-                    response.should.deep.equal({
-                        one: "one",
-                        two: "two",
-                        ref: response
-                    })
 
                     done()
                     client.close()
@@ -386,12 +350,7 @@ describe("Client", function()
         before(function(done)
         {
             client = new WebSocket("ws://" + host + ":" + port)
-
-            client.on("open", function()
-            {
-                client.subscribe("circularUpdate")
-                done()
-            })
+            client.once("open", done)
         })
 
         after(function(done)
@@ -485,28 +444,6 @@ describe("Client", function()
             {
                 obj.should.be.an.instanceOf(Object)
                 expect(obj).to.deep.equal({ foo: "bar", boo: "baz" })
-                done()
-            })
-        })
-
-        it("should receive an event with circular object", function(done)
-        {
-            const Obj = function()
-            {
-                this.one = "one"
-                this.two = "two"
-                this.ref = this
-            }
-
-            server.emit("circularUpdate", new Obj())
-
-            client.once("circularUpdate", function(value)
-            {
-                value.should.deep.equal({
-                    one: "one",
-                    two: "two",
-                    ref: value
-                })
                 done()
             })
         })

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -333,7 +333,7 @@ describe("Server", function()
                 host = server.wss.options.host
                 port = server.wss.options.port
 
-                auth_id = null
+                let auth_id = null
 
                 inst.setAuth(function(data, socket_id)
                 {
@@ -398,21 +398,9 @@ describe("Server", function()
                     throw new Error("Server error details")
                 })
 
-                inst.register("circular", function()
-                {
-                    const Obj = function()
-                    {
-                        this.one = "one"
-                        this.two = "two"
-                        this.ref = this
-                    }
-
-                    return new Obj()
-                })
-
                 inst.event("newMail")
                 inst.event("updatedNews")
-                inst.event("circularUpdate")
+
 
                 done()
             })
@@ -522,39 +510,6 @@ describe("Server", function()
 
                         message.id.should.equal(rpc_id)
                         message.result.should.equal(19)
-
-                        rpc_id++
-                        ws.close()
-                        done()
-                    })
-
-                    ws.once("error", function(error)
-                    {
-                        done(error)
-                    })
-                })
-            })
-
-            it("should return a valid response with circular object references", function(done)
-            {
-                connect(port, host).then(function(ws)
-                {
-                    ws.send(JSON.stringify({
-                        id: rpc_id,
-                        jsonrpc: "2.0",
-                        method: "circular"
-                    }))
-
-                    ws.on("message", function(message)
-                    {
-                        message = JSON.parse(message)
-
-                        message.id.should.equal(rpc_id)
-                        message.result.should.deep.equal({
-                            one: "one",
-                            two: "two",
-                            ref: "~result"
-                        })
 
                         rpc_id++
                         ws.close()
@@ -805,17 +760,17 @@ describe("Server", function()
                             {
                                 jsonrpc: "2.0",
                                 result: "Hello, Charles!",
-                                id: 9
+                                id: 8
                             },
                             {
                                 jsonrpc: "2.0",
                                 result: 7,
-                                id: 10
+                                id: 9
                             },
                             {
                                 jsonrpc: "2.0",
                                 result: 21,
-                                id: 11
+                                id: 10
                             }])
 
                         rpc_id++
@@ -1148,56 +1103,6 @@ describe("Server", function()
 
                         if (message.result.updatedNews === "ok")
                             return server.emit("updatedNews", "fox", "mtv", "eurosport")
-                    })
-
-                    ws.once("error", function(error)
-                    {
-                        done(error)
-                    })
-                })
-            })
-
-            it("should emit an event with circular objects to subscribed clients", function(done)
-            {
-                connect(port, host).then(function(ws)
-                {
-                    ws.send(JSON.stringify({
-                        id: ++rpc_id,
-                        jsonrpc: "2.0",
-                        method: "rpc.on",
-                        params: ["circularUpdate"]
-                    }))
-
-                    ws.on("message", function(message)
-                    {
-                        try { message = JSON.parse(message) }
-
-                        catch (error) { done(error) }
-
-                        if (message.notification)
-                        {
-                            message.notification.should.equal("circularUpdate")
-                            expect(message.params).to.deep.equal({
-                                one: "one",
-                                two: "two",
-                                ref: "~params"
-                            })
-
-                            ws.close()
-                            return done()
-                        }
-
-                        if (message.result.circularUpdate === "ok")
-                        {
-                            const Obj = function()
-                            {
-                                this.one = "one"
-                                this.two = "two"
-                                this.ref = this
-                            }
-
-                            return server.emit("circularUpdate", new Obj())
-                        }
                     })
 
                     ws.once("error", function(error)


### PR DESCRIPTION
JSON-RPC 2.0 requires inputs and outputs to be plain JSON, but `flatted` uses a different serialization algorithm, even for non-circular objects, and this breaks the compatibility. Before `flatted`, `circular-json` was used and it seemed to be compatible with JSON for non-circular objects. So it seems like reverting to it could be the right option here but it's not guaranteed to be JSON compatible either. So, for the short term, it looks like it's the best option to remove circular object support. A long term solution without breaking JSON-RPC compatibility could be developed after.

Before this change, only 26 of 75 tests were passing, now all of them pass.