### PR TITLE
fix: ESM support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^8.3.4",
         "@types/ws": "^8.2.2",
         "buffer": "^6.0.3",
-        "eventemitter3": "^4.0.7",
+        "eventemitter3": "^5.0.1",
         "uuid": "^8.3.2",
         "ws": "^8.5.0"
       },
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/uuid": "^8.3.4",
     "@types/ws": "^8.2.2",
     "buffer": "^6.0.3",
-    "eventemitter3": "^4.0.7",
+    "eventemitter3": "^5.0.1",
     "uuid": "^8.3.2",
     "ws": "^8.5.0"
   },


### PR DESCRIPTION
I just updated eventemitter3 to the latest version(v5.0.1) which supports ESM.


The current version(v4.0.7) can't work with the ESM build. According to the release note of [eventemitter3](https://github.com/primus/eventemitter3/releases/tag/5.0.0), ESM is supported from v5
![image](https://github.com/elpheria/rpc-websockets/assets/37807381/0c68f278-7f0f-4a9a-aab0-69df4fe77405)

> The above error occurs when used with Nuxt

**I'm not quite sure if I need to upload `dist/index.browser-bundle.js`, it will be changed by this modification**
