### PR TITLE
support string id

### DIFF
--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -17,7 +17,7 @@ export class Client extends CommonClient
         generate_request_id?: (
       method: string,
       params: object | Array<any>
-    ) => number
+    ) => number | string
     )
     {
         super(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export class Client extends CommonClient
         generate_request_id?: (
       method: string,
       params: object | Array<any>
-    ) => number
+    ) => number | string
     )
     {
         super(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -26,7 +26,7 @@ interface IQueueElement {
 }
 
 export interface IQueue {
-  [x: number]: IQueueElement;
+  [x: number | string]: IQueueElement;
 }
 
 export interface IWSRequestParams {
@@ -37,7 +37,7 @@ export interface IWSRequestParams {
 export class CommonClient extends EventEmitter
 {
     private address: string
-    private rpc_id: number
+    private rpc_id: number | string
     private queue: IQueue
     private options: IWSClientAdditionalOptions & NodeWebSocket.ClientOptions
     private autoconnect: boolean
@@ -52,7 +52,7 @@ export class CommonClient extends EventEmitter
     private generate_request_id: (
     method: string,
     params: object | Array<any>
-  ) => number
+  ) => number | string
     private socket: ICommonWebSocket
     private webSocketFactory: ICommonWebSocketFactory
     private dataPack: DataPack<object, string>
@@ -80,7 +80,7 @@ export class CommonClient extends EventEmitter
         generate_request_id?: (
       method: string,
       params: object | Array<any>
-    ) => number,
+    ) => number | string,
         dataPack?: DataPack<object, string>
     )
     {
@@ -100,7 +100,7 @@ export class CommonClient extends EventEmitter
         this.max_reconnects = max_reconnects
         this.rest_options = rest_options
         this.current_reconnects = 0
-        this.generate_request_id = generate_request_id || (() => ++this.rpc_id)
+        this.generate_request_id = generate_request_id || (() => Number(this.rpc_id) + 1)
 
         if (!dataPack) this.dataPack = new DefaultDataPack()
         else this.dataPack = dataPack

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -158,6 +158,29 @@ describe("Client", function()
             })
         })
 
+        it("should call an RPC method with string id receive a valid response", function(done)
+        {
+            let count = 1
+            const client = new WebSocket("ws://" + host + ":" + port, {}, (method) => {
+                count = count + 1
+                return `${method}-${count}`
+            })
+
+            client.on("open", function()
+            {
+                client.call("sum", [5, 3]).then(function(response)
+                {
+                    response.should.equal(8)
+
+                    done()
+                    client.close()
+                }, function(error)
+                {
+                    done(error)
+                })
+            })
+        })
+
         it("should forward ws options to ws.send", function(done)
         {
             const client = new WebSocket("ws://" + host + ":" + port)


### PR DESCRIPTION
According to the JSON-RPC spec (https://www.jsonrpc.org/specification), string ids are legal. I am interacting with a server that expects string id's, and didn't have that feature available. This pull request adds the ability to work with string id.