### PR TITLE
Namespace event should only send to subscriber

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -374,7 +374,7 @@ export class Server extends EventEmitter
        */
             emit(event: string, ...params: Array<string>)
             {
-                const nsEvent = self.namespaces[name].events[event.replace(/^\//, "")]
+                const nsEvent = self.namespaces[name].events[event]
                 if (nsEvent)
                     for (const socket_id of nsEvent.sockets)
                     {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -374,17 +374,19 @@ export class Server extends EventEmitter
        */
             emit(event: string, ...params: Array<string>)
             {
-                const socket_ids = [...self.namespaces[name].clients.keys()]
-
-                for (let i = 0, id; (id = socket_ids[i]); ++i)
-                {
-                    self.namespaces[name].clients.get(id).send(
-                        self.dataPack.encode({
-                            notification: event,
-                            params: params || [],
-                        })
-                    )
-                }
+                const nsEvent = self.namespaces[name].events[event.replace(/^\//, "")]
+                if (nsEvent)
+                    for (const socket_id of nsEvent.sockets)
+                    {
+                        const socket = self.namespaces[name].clients.get(socket_id)
+                        if (!socket) continue
+                        socket.send(
+                            self.dataPack.encode({
+                                notification: event,
+                                params,
+                            })
+                        )
+                    }
             },
 
             /**

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -629,7 +629,7 @@ describe("Client", function()
             })
         })
 
-        it("should receive an event from a joined namespace", function(done)
+        it("should not receive an event from a joined namespace if wasn't subscribed", function(done)
         {
             const chat = server.of("/chat")
             chat.emit("chatMessage")

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -633,13 +633,40 @@ describe("Client", function()
         {
             const chat = server.of("/chat")
             chat.emit("chatMessage")
-
-            client.once("chatMessage", function()
+            let received = false
+            client.once("chatMessage", function ()
             {
-                done()
+                received = true
             })
+            setTimeout(function ()
+            {
+                if (received)
+                {
+                    done(new Error("should not receive the event as didn't subscribed"))
+                } else {
+                    done()
+                }
+            }, 500)
         })
 
+        it("should receive an event from a joined namespace after subscribed", function (done)
+        {
+            client.subscribe("chatMessage").then(function (data)
+            {
+                data.should.have.property("chatMessage")
+                data.chatMessage.should.equal("ok")
+                const chat = server.of("/chat")
+                chat.emit("chatMessage")
+                client.once("chatMessage", function ()
+                {
+                    done()
+                })
+            }).catch(function (error)
+            {
+                done(error)
+            })
+        })
+        
         it("should receive params from an event correctly", function(done)
         {
             const ns = server.of("/test")


### PR DESCRIPTION
This is to address the issue flagged https://github.com/elpheria/rpc-websockets/issues/155

Which the current logic of emitting an event inside a nameside will broadcast to all connected client instead of only the client subscribed to the event

**This will be a breaking change if any implementation was incorrectly relied on the broadcasting beavhiour without subscribing**