### PR TITLE
feat/gracefully handle login when client disconnects

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -856,8 +856,6 @@ var Server = class extends eventemitter3.EventEmitter {
       if (s) {
         s["_authenticated"] = true;
         this.namespaces[ns].clients.set(socket_id, s);
-      } else {
-        console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns });
       }
     }
     return {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -853,8 +853,12 @@ var Server = class extends eventemitter3.EventEmitter {
     if (!message.id) return;
     if (message.method === "rpc.login" && response === true) {
       const s = this.namespaces[ns].clients.get(socket_id);
-      s["_authenticated"] = true;
-      this.namespaces[ns].clients.set(socket_id, s);
+      if (s) {
+        s["_authenticated"] = true;
+        this.namespaces[ns].clients.set(socket_id, s);
+      } else {
+        console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns });
+      }
     }
     return {
       jsonrpc: "2.0",

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -846,8 +846,12 @@ var Server = class extends EventEmitter {
     if (!message.id) return;
     if (message.method === "rpc.login" && response === true) {
       const s = this.namespaces[ns].clients.get(socket_id);
-      s["_authenticated"] = true;
-      this.namespaces[ns].clients.set(socket_id, s);
+      if (s) {
+        s["_authenticated"] = true;
+        this.namespaces[ns].clients.set(socket_id, s);
+      } else {
+        console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns });
+      }
     }
     return {
       jsonrpc: "2.0",

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -849,8 +849,6 @@ var Server = class extends EventEmitter {
       if (s) {
         s["_authenticated"] = true;
         this.namespaces[ns].clients.set(socket_id, s);
-      } else {
-        console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns });
       }
     }
     return {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -778,10 +778,6 @@ export class Server extends EventEmitter
                 s["_authenticated"] = true
                 this.namespaces[ns].clients.set(socket_id, s)
             }
-            else
-            {
-                console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns })
-            }
         }
 
         return {

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -773,8 +773,15 @@ export class Server extends EventEmitter
         if (message.method === "rpc.login" && response === true)
         {
             const s = this.namespaces[ns].clients.get(socket_id)
-            s["_authenticated"] = true
-            this.namespaces[ns].clients.set(socket_id, s)
+            if (s)
+            {
+                s["_authenticated"] = true
+                this.namespaces[ns].clients.set(socket_id, s)
+            }
+            else
+            {
+                console.warn("rpc.login succeeded after socket disconnected", { socket_id, ns })
+            }
         }
 
         return {

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -1286,6 +1286,87 @@ describe("Server", function()
                 })
             })
 
+            it("should stay available if client disconnects before async login resolves", function(done)
+            {
+                let raceServer = null
+                const racePort = 41001
+
+                function finish(error)
+                {
+                    if (!raceServer) return done(error)
+
+                    raceServer.close().then(function()
+                    {
+                        done(error)
+                    }, done)
+                }
+
+                getInstance(racePort).then((inst) =>
+                {
+                    raceServer = inst
+
+                    inst.setAuth(function(data)
+                    {
+                        return new Promise(function(resolve)
+                        {
+                            setTimeout(function()
+                            {
+                                resolve(data.username === "foo" && data.password === "bar")
+                            }, 50)
+                        })
+                    })
+
+                    return connect(racePort, inst.wss.options.host)
+                }).then((ws) =>
+                {
+                    ws.send(JSON.stringify({
+                        id: ++rpc_id,
+                        jsonrpc: "2.0",
+                        method: "rpc.login",
+                        params: {
+                            username: "foo",
+                            password: "bar"
+                        }
+                    }))
+
+                    setTimeout(function()
+                    {
+                        ws.close()
+                    }, 1)
+
+                    setTimeout(function()
+                    {
+                        connect(racePort, raceServer.wss.options.host).then((probeWs) =>
+                        {
+                            const probeId = ++rpc_id
+
+                            probeWs.send(JSON.stringify({
+                                id: probeId,
+                                jsonrpc: "2.0",
+                                method: "rpc.login",
+                                params: {
+                                    username: "foo",
+                                    password: "bar2"
+                                }
+                            }))
+
+                            probeWs.once("message", function(message)
+                            {
+                                message = JSON.parse(message)
+
+                                message.id.should.equal(probeId)
+                                message.result.should.equal(false)
+
+                                probeWs.close()
+                                finish()
+                            })
+
+                            probeWs.once("error", finish)
+                        }).catch(finish)
+                    }, 75)
+                }).catch(finish)
+            })
+
             it("should return a valid response if authorized", function(done)
             {
                 connect(port, host).then((ws) =>


### PR DESCRIPTION
The issue I am facing is that when an rpc-websocket client disconnects before the auth is complete the server crashes.

This happens because the auth handler tries to get the mutate the current socket connection with s["_authenticated"] = true; Which fails as s is now undefined, killed when the client disconnects

This fix solves it by only mutating it if s is found. 

I've tested this in my local project as well as added a unit test for this